### PR TITLE
Introduce strict do-exclusively script but only for workflow

### DIFF
--- a/tools/do-exclusively-workflow.sh
+++ b/tools/do-exclusively-workflow.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+# sets $branch, $tag, $rest
+parse_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            # -b|--branch) branch="$2" ;;
+            # -t|--tag) tag="$2" ;;
+            -w|--workflow) workflow="$2" ;;
+            *) break ;;
+        esac
+        shift 2
+    done
+    rest=("$@")
+}
+
+v2api() {
+    command curl -sSfL -H "Accept: application/json" -H "Circle-Token: $CIRCLE_TOKEN" "$@"
+}
+
+not_finished_workflow_ids() {
+    local -r workflow_name="$1"
+    local -r api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
+
+    curl -X GET -H "Accept: application/json" "$api_url" | \
+        jq -r \
+        --arg workflow_name "$workflow_name" \
+        --arg my_build_num "$CIRCLE_BUILD_NUM" \
+        '.[] | select(.status | test(\"running|pending|queued\") and .workflows.workflow_name == $workflow_name) and .build_num != $my_build_num | .workflow_id'
+}
+
+parse_args
+
+# e.g. 2020-04-01T10:46:48Z
+readonly created_at_of_my_workflow="$(v2api -X GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID" | jq -r '.created_at')"
+
+# Lock
+while true; do
+    ok="ok"
+
+    # repeat until there is no workflow that has not been finished yet except me
+    while read workflow_id; do
+        ok="ng"
+        created_at="$(api_call -X GET "https://circleci.com/api/v2/workflow/$workflow_id" | jq -r '.created_at')"
+
+        if [[ "$(ruby -r 'time' -e 'puts Time.parse(ARGV[0]) < Time.parse(ARGV[1])' "$created_at_of_my_workflow" < "$created_at")" == "true" ]]; then
+            # cancel myself because this workflow has been *old*
+            v2api -X POST "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel"
+            echo "Canceling..."
+            exit 1
+        fi
+    done < <(not_finished_workflow_ids "$workflow")
+
+    if [[ "$ok" == "ok" ]]; then
+        break
+    else
+        echo "Retrying in 5 seconds..."
+        sleep 5
+    fi
+done
+
+echo "Acquired lock"
+
+if [[ "${#rest[@]}" -ne 0 ]]; then
+    "${rest[@]}"
+fi

--- a/tools/do-exclusively-workflow.sh
+++ b/tools/do-exclusively-workflow.sh
@@ -26,10 +26,10 @@ not_finished_workflow_ids() {
         jq -r \
         --arg workflow_name "$workflow_name" \
         --arg my_build_num "$CIRCLE_BUILD_NUM" \
-        '.[] | select(.status | test(\"running|pending|queued\") and .workflows.workflow_name == $workflow_name) and .build_num != $my_build_num | .workflow_id'
+        '.[] | select((.status | test("running|pending|queued")) and .workflows.workflow_name == $workflow_name and .build_num != $my_build_num) | .workflows.workflow_id'
 }
 
-parse_args
+parse_args "$@"
 
 # e.g. 2020-04-01T10:46:48Z
 readonly created_at_of_my_workflow="$(v2api -X GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID" | jq -r '.created_at')"
@@ -40,17 +40,24 @@ while true; do
 
     # repeat until there is no workflow that has not been finished yet except me
     while read workflow_id; do
+        echo "$workflow_id is running..."
+
         ok="ng"
-        created_at="$(api_call -X GET "https://circleci.com/api/v2/workflow/$workflow_id" | jq -r '.created_at')"
+        created_at="$(v2api -X GET "https://circleci.com/api/v2/workflow/$workflow_id" | jq -r '.created_at')"
+
+        echo "I was created at $created_at_of_my_workflow but the workflow ($workflow_id) was created at $created_at... so?"
 
         if [[ "$(ruby -r 'time' -e 'puts Time.parse(ARGV[0]) < Time.parse(ARGV[1])' "$created_at_of_my_workflow" "$created_at")" == "true" ]]; then
             # cancel myself because this workflow has been *old*
             echo "Canceling myself..."
             exec circleci step halt
+        else
+            echo "I'm newer! Wait to acquire the lock..."
         fi
     done < <(not_finished_workflow_ids "$workflow")
 
     if [[ "$ok" == "ok" ]]; then
+        echo "Hooray!"
         break
     else
         echo "Retrying in 5 seconds..."

--- a/tools/do-exclusively-workflow.sh
+++ b/tools/do-exclusively-workflow.sh
@@ -45,9 +45,9 @@ while true; do
 
         if [[ "$(ruby -r 'time' -e 'puts Time.parse(ARGV[0]) < Time.parse(ARGV[1])' "$created_at_of_my_workflow" < "$created_at")" == "true" ]]; then
             # cancel myself because this workflow has been *old*
-            v2api -X POST "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/cancel"
-            echo "Canceling..."
-            exit 1
+            circleci step halt
+            echo "Canceled myself"
+            exit 0
         fi
     done < <(not_finished_workflow_ids "$workflow")
 

--- a/tools/do-exclusively-workflow.sh
+++ b/tools/do-exclusively-workflow.sh
@@ -43,11 +43,10 @@ while true; do
         ok="ng"
         created_at="$(api_call -X GET "https://circleci.com/api/v2/workflow/$workflow_id" | jq -r '.created_at')"
 
-        if [[ "$(ruby -r 'time' -e 'puts Time.parse(ARGV[0]) < Time.parse(ARGV[1])' "$created_at_of_my_workflow" < "$created_at")" == "true" ]]; then
+        if [[ "$(ruby -r 'time' -e 'puts Time.parse(ARGV[0]) < Time.parse(ARGV[1])' "$created_at_of_my_workflow" "$created_at")" == "true" ]]; then
             # cancel myself because this workflow has been *old*
-            circleci step halt
-            echo "Canceled myself"
-            exit 0
+            echo "Canceling myself..."
+            exec circleci step halt
         fi
     done < <(not_finished_workflow_ids "$workflow")
 
@@ -61,6 +60,4 @@ done
 
 echo "Acquired lock"
 
-if [[ "${#rest[@]}" -ne 0 ]]; then
-    "${rest[@]}"
-fi
+exec "${rest[@]}"


### PR DESCRIPTION
The strategy is like the following:

1. The current workflow fetches workflows that have not been finished regardless of their results, except itself
2. Try to pick up the head of the not-yet-finished workflows and step into `3` but go to Step5 if unavailable.
3. Compare `created_at` of the current workflow and the workflow picked up in the Step2.
4. If the current workflow looks old, then it will halt itself. Otherwise, repeat back to `Step2`.
5. Acquire the lock and proceed!

Requirements

- Ruby
- jq