### PR TITLE
version 番号を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docker-circleci-plus-infra-tool",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "https://cloud.docker.com/repository/docker/ainoya/circleci-infra-tools",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
現状 0.46 のバージョンが既に存在しているようで、 release に失敗していたので `package.json` のバージョンを修正しました