### PR TITLE
ver. up terraform 1.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp/terraform:0.15.5
+FROM hashicorp/terraform:1.0.0
 ARG tfnotify_ver=v0.7.0
 ARG assume_role_ver=0.3.2
 ARG kustomize_ver=v3.6.1


### PR DESCRIPTION
Upgrade terraform to `1.0.0` looks no big difference between `0.15.5` and `1.0.0`