### PR TITLE
Install buildx plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ RUN tar zxf stone.tar.gz && \
   cd stone-*/ && \
   FLAGS=-D_GNU_SOURCE make linux && chmod +x stone && \
   cp stone /tmp/stone
+FROM alpine AS buildx
+ARG BUILDX_VERSION=0.6.1
+ADD https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64 /docker-buildx
+RUN chmod a+x /docker-buildx
 FROM circleci/ruby:2.7.1-node
 COPY --from=0 /bin/terraform /bin
 COPY --from=0 /bin/tfnotify /bin
@@ -41,6 +45,7 @@ COPY --from=0 /bin/kubectl /bin
 COPY --from=0 /bin/kubesec /bin
 COPY --from=0 /bin/kustomize /bin
 COPY --from=1 /tmp/stone /bin
+COPY --from=buildx /docker-buildx /usr/lib/docker/cli-plugins/docker-buildx
 RUN sudo apt-get -y update \
   && sudo apt -y install mariadb-client python3 python3-pip mariadb-server redis groff-base \
   && pip3 install awscli mycli datadog \


### PR DESCRIPTION
Added `buildx` plugin (https://github.com/docker/buildx) to be available to use for multi-arch build.

I checked that I can use `buildx` docker command and properly installed on following steps after image buillt as `test-image`

```
$ docker run -v /var/run/docker.sock:/var/run/docker.sock --privileged -u root -it --rm test-image /bin/bash

root@f9489a1e34de:/# docker buildx version
github.com/docker/buildx v0.6.1 260d07a9a19b03df969787496419a0808a27ac61
```